### PR TITLE
genvm: replace '&&' by 'if' for post install

### DIFF
--- a/genvm
+++ b/genvm
@@ -772,10 +772,10 @@ execute_post_install () {
 		[ -d "${THIRD}" ] && {
 			for _file in $(find "${THIRD}" \( -type f -o -type l \) \
 				-a -regex "${THIRD}/[0-9]+.*" | sort) ; do
-				echo ${_file} | grep -P "[0-9]{2}\.post.*" && {
+				if echo ${_file} | grep -P "[0-9]{2}\.post.*"; then
 					echo "Running ${_file} after all"
 					source ${_file}
-				}
+				fi
 			done
 		}
 	done


### PR DESCRIPTION
genvm often returns an exit code <code>$?</code> not equal to 0, even if the script completed gracefully. It is related to the <code>grep</code> in <code>execute_post_install</code>.
If a file previously found doesn't match the <code>grep</code> and if it is the last file in the list, <code>genvm</code> will exit with a <code>$?</code> not equal to 0.